### PR TITLE
set delete default method dataAsQueryString true

### DIFF
--- a/lib/service_client.js
+++ b/lib/service_client.js
@@ -287,6 +287,7 @@ class ServiceClient {
       dataType: 'json',
       contentType: 'json',
       data,
+      dataAsQueryString: true,
       timeout: this.timeout || 60000
     };
     _.merge(options, opt);


### PR DESCRIPTION
Now cosmo-azk system default accept querystring on delete method. With out this default option(dataAsQueryString), cosmo-azk will not accept query param and throw exception 'sign error'.